### PR TITLE
Add support for tmux windows and flexible command timeout

### DIFF
--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -4,13 +4,34 @@ cmdignore=(htop tmux top vim)
 # set gt 0 to enable GNU units for time results
 gnuunits=0
 
+# Figure out the active Tmux window
+function active_tmux_window() {
+    [ -n "$TMUX" ] || {
+        echo notmux
+        return 1
+    }
+    tmux display-message -p '#W'
+}
+
+function active_tmux_session() {
+    [ -n "$TMUX" ] || {
+        echo notmux
+        return 1
+    }
+    tmux display-message -p '#S'
+}
+
 # Function taken from undistract-me, get the current window id
-function active_window_id () {
+function active_window_id() {
     if [[ -n $DISPLAY ]] ; then
         xprop -root _NET_ACTIVE_WINDOW | awk '{print $5}'
         return
     fi
     echo nowindowid
+}
+
+function is_window_unfocused() {
+    [[ "$cmd_active_win" != $(active_window_id) ]] || [[ "$cmd_tmux_win" != $(active_tmux_window) ]]
 }
 
 # end and compare timer, notify-send if needed
@@ -24,7 +45,7 @@ function notifyosd-precmd() {
             ((cmd_secs=$cmd_end - $cmd_start))
         fi
 
-        if [ ! -z "$cmd" -a $cmd_secs -gt 10 ] && [[ "$cmd_active_win" != "$(active_window_id)" ]]; then
+        if [ ! -z "$cmd" -a $cmd_secs -gt 10 ] && is_window_unfocused; then
             if [ $retval -gt 0 ]; then
                 cmdstat="with warning"
                 sndstat="/usr/share/sounds/gnome/default/alerts/sonar.ogg"
@@ -42,13 +63,18 @@ function notifyosd-precmd() {
                 cmd_time="$cmd_secs seconds"
             fi
 
+            tmux_info=''
+            if active_tmux_window >/dev/null; then
+                tmux_info="(tmux: $cmd_tmux_session/$cmd_tmux_win)"
+            fi
+
             if [ ! -z $SSH_TTY ] ; then
                 notify-send -i utilities-terminal \
-                        -u $urgency "$cmd_basename on $(hostname) completed $cmdstat" "\"$cmd\" took $cmd_time"; \
+                        -u $urgency "$cmd_basename on $(hostname) completed $cmdstat" "\"$cmd\" took $cmd_time $tmux_info"; \
                         play -q $sndstat
             else
                 notify-send -i utilities-terminal \
-                        -u $urgency "$cmd_basename completed $cmdstat" "\"$cmd\" took $cmd_time"; \
+                        -u $urgency "$cmd_basename completed $cmdstat" "\"$cmd\" took $cmd_time $tmux_info"; \
                         play -q $sndstat
             fi
         fi
@@ -65,6 +91,8 @@ function notifyosd-preexec() {
     cmd_basename=${${cmd:s/sudo //}[(ws: :)1]} 
     cmd_start=$(date +%s)
     cmd_active_win=$(active_window_id)
+    cmd_tmux_win=$(active_tmux_window)
+    cmd_tmux_session=$(active_tmux_session)
 }
 
 # make sure this plays nicely with any existing preexec

--- a/notifyosd.zsh
+++ b/notifyosd.zsh
@@ -1,8 +1,11 @@
+# Default timeout is 10 seconds.
+LONG_RUNNING_COMMAND_TIMEOUT=${LONG_RUNNING_COMMAND_TIMEOUT:-10}
+
+# Set gt 0 to enable GNU units for time results. Disabled by default.
+NOTIFYOSD_GNUUNITS=${NOTIFYOSD_GNUUNITS:-0}
+
 # commands to ignore
 cmdignore=(htop tmux top vim)
-
-# set gt 0 to enable GNU units for time results
-gnuunits=0
 
 # Figure out the active Tmux window
 function active_tmux_window() {
@@ -45,7 +48,7 @@ function notifyosd-precmd() {
             ((cmd_secs=$cmd_end - $cmd_start))
         fi
 
-        if [ ! -z "$cmd" -a $cmd_secs -gt 10 ] && is_window_unfocused; then
+        if [ ! -z "$cmd" -a $cmd_secs -gt ${LONG_RUNNING_COMMAND_TIMEOUT:-10} ] && is_window_unfocused; then
             if [ $retval -gt 0 ]; then
                 cmdstat="with warning"
                 sndstat="/usr/share/sounds/gnome/default/alerts/sonar.ogg"
@@ -56,7 +59,7 @@ function notifyosd-precmd() {
                 urgency="normal"
             fi
 
-            if [ $gnuunits -gt 0 ]; then
+            if [ "$NOTIFYOSD_GNUUNITS" -gt 0 ]; then
                 cmd_time=$(units "$cmd_secs seconds" "centuries;years;months;weeks;days;hours;minutes;seconds" | \
                         sed -e 's/\ +/\,/g' -e s'/\t//')
             else


### PR DESCRIPTION
If a long running command is run from a tmux window, on completion, it
verifies that the tmux window differs before triggering a notification.

Information about the tmux session related to the completed
command is added to the notification to make it easier to figure out in
which tmux window the command was being executed.